### PR TITLE
Credentials file comments and PowerShell USERPROFILE for home directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,3 +58,9 @@ of making a fork and pull request yourself:
 Please use clear commit messages so we can understand what each commit does.
 We'll review every PR and might offer feedback or request changes before
 merging.
+
+## Local build and test
+
+- pip install build # Install the build library
+- python -m build # Build this library with your changes
+- pip install . # Install built library locally

--- a/min_requirements.txt
+++ b/min_requirements.txt
@@ -3,3 +3,4 @@ charset-normalizer==2.1.1
 idna==3.3
 requests==2.28.1
 urllib3==1.26.12
+json5==0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ charset-normalizer==2.1.1
 idna==3.3
 requests==2.28.1
 urllib3==1.26.12
+json5==0.12.0

--- a/src/pcpi/session_loader.py
+++ b/src/pcpi/session_loader.py
@@ -344,7 +344,11 @@ def load_config(file_path='', num_tenants=-1, min_tenants=-1, logger=py_logger):
         exit()
 
     if file_path == '':
-        config_dir = os.path.join(os.environ['HOME'], '.prismacloud')
+        env_vars = os.environ.keys()
+        if "HOME" in env_vars:
+            config_dir = os.path.join(os.environ['HOME'], '.prismacloud')
+        elif "USERPROFILE" in env_vars:
+            config_dir = os.path.join(os.environ['USERPROFILE'], '.prismacloud')
         config_path = os.path.join(config_dir, 'credentials.json')
         if not os.path.exists(config_dir):
             os.mkdir(config_dir)

--- a/src/pcpi/session_loader.py
+++ b/src/pcpi/session_loader.py
@@ -2,7 +2,7 @@
 import os
 import re
 import logging
-import json
+import json5
 
 #Installed
 import requests
@@ -356,12 +356,12 @@ def load_config(file_path='', num_tenants=-1, min_tenants=-1, logger=py_logger):
     if not os.path.exists(config_path):
         config = __get_config_from_user(num_tenants, min_tenants)
         with open(config_path, 'w') as outfile:
-            json.dump(config, outfile)
+            json5.dump(config, outfile)
 
     config_data = {}
     with open(config_path, 'r') as infile:
         try:
-            config_data = json.load(infile)
+            config_data = json5.load(infile)
         except Exception as e:
             logger.error('Failed to load credentials file. Exiting...')
             logger.log(e)


### PR DESCRIPTION
## Description

We found that the library fails if there are any comments in the credentials json files so to handle this I use the json5 library instead of the base json library that comes with python at this time. 
https://pypi.org/project/json5/

I also saw the library fail to find credential files when using PowerShell because the environment variable HOME would be missing. I set it to fall back onto USERPROFILE if the HOME variable is not set. 

I also added more descriptive notes on how to test locally in the CONTRIBUTING.md file.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I tested locally in a minimal capacity.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
